### PR TITLE
WIP - Consume messages to create post database entries

### DIFF
--- a/kino_webapp/lib/kino_webapp.ex
+++ b/kino_webapp/lib/kino_webapp.ex
@@ -7,12 +7,9 @@ defmodule KinoWebapp do
     import Supervisor.Spec, warn: false
 
     children = [
-      # Start the endpoint when the application starts
       supervisor(KinoWebapp.Endpoint, []),
-      # Start the Ecto repository
       worker(KinoWebapp.Repo, []),
-      # Here you could define other workers and supervisors as children
-      # worker(KinoWebapp.Worker, [arg1, arg2, arg3]),
+      worker(KinoWebapp.MessageConsumer, [])
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/kino_webapp/lib/kino_webapp/message_consumer.ex
+++ b/kino_webapp/lib/kino_webapp/message_consumer.ex
@@ -1,0 +1,44 @@
+defmodule KinoWebapp.MessageConsumer do
+  use GenServer
+  use AMQP
+
+  def start_link do
+    GenServer.start_link(__MODULE__, [], [])
+  end
+
+  @queue       "file_created"
+  @queue_error "#{@queue}_error"
+  @exchange    ""
+
+  def init(_opts) do
+    {:ok, conn} = Connection.open("amqp://guest:guest@rabbitmq.local:5672")
+    {:ok, chan} = Channel.open(conn)
+    Basic.qos(chan, prefetch_count: 10)
+    Queue.declare(chan, @queue, durable: true)
+
+    {:ok, _consumer_tag} = Basic.consume(chan, @queue)
+    {:ok, chan}
+  end
+
+  def handle_info({:basic_consume_ok, %{consumer_tag: consumer_tag}}, chan) do
+    {:noreply, chan}
+  end
+
+  def handle_info({:basic_cancel, %{consumer_tag: consuemr_tag}}, chan) do
+    {:stop, :normal, chan}
+  end
+
+  def handle_info({:basic_cancel_ok, %{consumer_tag: consuemr_tag}}, chan) do
+    {:noreply, chan}
+  end
+
+  def handle_info({:basic_deliver, payload, %{delivery_tag: delivery_tag, redelivered: redelivered}}, chan) do
+    %{"contents" => contents, "path" => file_path, "name" => file_name} = Poison.decode!(payload)
+    full_file_name = Path.join(file_path, file_name)
+    post = %KinoWebapp.Post{:content => contents, :key => full_file_name}
+    KinoWebapp.Repo.insert!(post)
+
+    Basic.ack(chan, delivery_tag)
+    {:noreply, chan}
+  end
+end

--- a/kino_webapp/mix.exs
+++ b/kino_webapp/mix.exs
@@ -19,7 +19,7 @@ defmodule KinoWebapp.Mixfile do
   def application do
     [mod: {KinoWebapp, []},
      applications: [:phoenix, :phoenix_html, :cowboy, :logger,
-                    :phoenix_ecto, :postgrex]]
+                    :phoenix_ecto, :postgrex, :amqp]]
   end
 
   # Specifies which paths to compile per environment.
@@ -35,7 +35,10 @@ defmodule KinoWebapp.Mixfile do
      {:postgrex, ">= 0.0.0"},
      {:phoenix_html, "~> 2.1"},
      {:phoenix_live_reload, "~> 1.0", only: :dev},
-     {:cowboy, "~> 1.0"}]
+     {:cowboy, "~> 1.0"},
+     {:amqp, "0.1.4"},
+     {:poison, "~> 1.5"}]
+
   end
 
   # Aliases are shortcut or tasks specific to the current project.

--- a/kino_webapp/mix.lock
+++ b/kino_webapp/mix.lock
@@ -1,4 +1,6 @@
-%{"connection": {:hex, :connection, "1.0.2"},
+%{"amqp": {:hex, :amqp, "0.1.4"},
+  "amqp_client": {:hex, :amqp_client, "3.5.6"},
+  "connection": {:hex, :connection, "1.0.2"},
   "cowboy": {:hex, :cowboy, "1.0.4"},
   "cowlib": {:hex, :cowlib, "1.0.2"},
   "decimal": {:hex, :decimal, "1.1.1"},
@@ -12,4 +14,5 @@
   "poison": {:hex, :poison, "1.5.0"},
   "poolboy": {:hex, :poolboy, "1.5.1"},
   "postgrex": {:hex, :postgrex, "0.10.0"},
+  "rabbit_common": {:hex, :rabbit_common, "3.5.6"},
   "ranch": {:hex, :ranch, "1.2.0"}}

--- a/kino_webapp/priv/repo/migrations/20160103081205_create_post.exs
+++ b/kino_webapp/priv/repo/migrations/20160103081205_create_post.exs
@@ -1,0 +1,14 @@
+defmodule KinoWebapp.Repo.Migrations.CreatePost do
+  use Ecto.Migration
+
+  def change do
+    create table(:posts) do
+      add :key, :text
+      add :content, :text
+
+      timestamps
+    end
+
+    create index(:posts, [:key], unique: true)
+  end
+end

--- a/kino_webapp/test/models/post_test.exs
+++ b/kino_webapp/test/models/post_test.exs
@@ -1,0 +1,18 @@
+defmodule KinoWebapp.PostTest do
+  use KinoWebapp.ModelCase
+
+  alias KinoWebapp.Post
+
+  @valid_attrs %{content: "some content", key: "some content"}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = Post.changeset(%Post{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = Post.changeset(%Post{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end

--- a/kino_webapp/web/models/post.ex
+++ b/kino_webapp/web/models/post.ex
@@ -1,0 +1,24 @@
+defmodule KinoWebapp.Post do
+  use KinoWebapp.Web, :model
+
+  schema "posts" do
+    field :key, :string
+    field :content, :string
+
+    timestamps
+  end
+
+  @required_fields ~w(key content)
+  @optional_fields ~w()
+
+  @doc """
+  Creates a changeset based on the `model` and `params`.
+
+  If no params are provided, an invalid changeset is returned
+  with no validation performed.
+  """
+  def changeset(model, params \\ :empty) do
+    model
+    |> cast(params, @required_fields, @optional_fields)
+  end
+end


### PR DESCRIPTION
This is a WIP PR, mostly to get your eyes on it @larquin. Here's how to fire this whole thing up:

0: On mac, make sure your docker-machine is running:

``` sh
$ docker-machine start default
$ eval $(docker-machine env default)
```

1: Start the notifier (which will also start rabbitmq and the ssh server):

``` sh
$ docker-compose run notifier bin/console
[1] pry(main)> Kino::Notifier::Observer.new("/home") # expect this to block
```

2: In another shell, start the mix task:

``` sh
$ docker-compose run webapp iex -S mix # won't block, iex starts
```

3: In another shell, write a file to the ssh server:

``` sh
# linux
$ echo "foo bar baz" | ssh -p 3500 testuser@localhost "cat > ~/foo8.md"

# mac
$ echo "foo bar baz" | ssh -p 3500 testuser@$(docker-machine ip default) "cat > ~/fooN.md"
```

After running that last command, you should see some log output in the ruby shell and some log output in the IEx session.

~~Right now, all this PR does is print a message from the elixir message consumer.~~ This PR optimistically shoves records in the database. Eventually, we'll probably want to handle this whole process better (retries, handling duplicate key violations, rate limiting, etc), but this is a start.

TODO:
- [x] Ack messages so AMQP will remove them from the queue
- [x] Create database entries for files created
- [x] Figure out how to run this as a persistent process (probably in a supervisor tree? still figuring this stuff out)
- [x] Clean up the commit history before merging
